### PR TITLE
Client MUST send empty Certificate message

### DIFF
--- a/draft-jhoyla-req-mtls-flag.md
+++ b/draft-jhoyla-req-mtls-flag.md
@@ -42,8 +42,8 @@ this hint.
 # Introduction
 
 This document specifies a TLS Flag {{!I-D.ietf-tls-tlsflags}} that allows a
-client to attempt to negotiate mutually authenticated TLS (in at least some
-cases). Sometimes a server does not want to authenticate every client, but
+client to prompt the server to request a client certificate during the
+handshake. Sometimes a server does not want to authenticate every client, but
 might wish to authenticate a subset of them. In TLS 1.3 this may be done with
 post-handshake authentication, however this adds an extra round trip, and
 requires negotiation at the application layer.
@@ -116,6 +116,9 @@ merely provides a hint that the client will handle the request gracefully.
 Because the server acknowledges the flag in the `CertificateRequest` the client
 can always be sure whether a `CertificateRequest` was triggered by
 `request_client_auth` or not.
+
+TODO: Discuss security considerations related to a flag that changes which
+trust anchors are offered and how to handle/authorise application data.
 
 # IANA Considerations
 

--- a/draft-jhoyla-req-mtls-flag.md
+++ b/draft-jhoyla-req-mtls-flag.md
@@ -5,7 +5,7 @@ category: info
 docname: draft-jhoyla-req-mtls-flag-latest
 submissiontype: IETF  # also: "independent", "editorial", "IAB", or "IRTF"
 number: 0
-date: 25/02/28
+date: 25/04/22
 consensus: true
 v: 3
 # area: SEC
@@ -32,8 +32,10 @@ informative:
 --- abstract
 
 Normally in TLS there is no way for the client to signal to the server that it
-has been configured with a certificate suitable for mTLS. This document defines
-a TLS Flag {{!I-D.ietf-tls-tlsflags}} that enables clients to provide this hint.
+supports client authentication and will handle a CertificateRequest by sending
+an empty Certificate message without terminating the connection. This document
+defines a TLS Flag {{!I-D.ietf-tls-tlsflags}} that enables clients to provide
+this hint.
 
 
 --- middle
@@ -41,14 +43,25 @@ a TLS Flag {{!I-D.ietf-tls-tlsflags}} that enables clients to provide this hint.
 # Introduction
 
 This document specifies a TLS Flag that indicates to the server that the client
-supports mTLS. Sometimes a server does not want to negotiate mTLS with every
-client, but might wish to authenticate a subset of them. In TLS 1.3 this may be
-done with post-handshake auth, however this adds an extra round-trip, and
-requires negotiation at the application layer. A client sending the request
-mTLS flag in the ClientHello allows the server to request authentication during
-the initial handshake only when it receives a hint the client supports it. This
-enables a number of use cases, for example allowing bots to authenticate
-themselves when mixed in with general traffic.
+supports mutually authenticated TLS (in at least some cases). Sometimes a server
+does not want to authenticate every client, but might wish to authenticate a
+subset of them. In TLS 1.3 this may be done with post-handshake auth, however
+this adds an extra round-trip, and requires negotiation at the application
+layer.
+
+The behaviour specified in {{?RFC8446}} for a client that receives a
+CertificateRequest that it cannot satisfy is to send an empty Certificate
+message followed by a Finished message. However in practice many clients simply
+terminate the connection in anticipation of a "certificate_required" alert.
+
+This behaviour makes it difficult for servers to send CertificateRequest
+messages in the wild. A client sending the request mTLS flag in the ClientHello
+allows the server to request authentication during the initial handshake only
+when it receives a hint the client will handle the request without terminating
+the connection, and, if unable to authenticate, by sending an empty certificate
+message, per {{?RFC8446, Section 4.4.2}}. This enables a number of use cases,
+for example allowing bots to authenticate themselves when mixed in with general
+traffic.
 
 # Conventions and Definitions
 
@@ -56,15 +69,17 @@ themselves when mixed in with general traffic.
 
 # Flag specification
 
-A server receiving this flag MAY send a CertificateRequest message.
+A server receiving this flag MAY send a CertificateRequest message, and a client
+sending this flag MUST send a Certificate message if it receives a
+CertificateRequest, even if said Certificate message is empty, and SHOULD NOT
+preemptively terminate the connection anticipating a "certificate_required"
+alert.
 
 # Security Considerations
 
 This flag should have no effect on the security of TLS, as the server may always
 send a CertificateRequest message during the handshake. This flag merely
-provides a hint that the client will be able to fulfil the request. If the
-client sets this flag but then fails to provide a certificate the server MAY
-terminate the connection with a bad_certificate error.
+provides a hint that the client will handle the request gracefully.
 
 # IANA Considerations
 

--- a/draft-jhoyla-req-mtls-flag.md
+++ b/draft-jhoyla-req-mtls-flag.md
@@ -5,7 +5,7 @@ category: info
 docname: draft-jhoyla-req-mtls-flag-latest
 submissiontype: IETF  # also: "independent", "editorial", "IAB", or "IRTF"
 number: 0
-date: 25/04/22
+date: 25/05/27
 consensus: true
 v: 3
 # area: SEC
@@ -32,30 +32,28 @@ informative:
 --- abstract
 
 Normally in TLS there is no way for the client to signal to the server that it
-supports client authentication and will handle a CertificateRequest by sending
-an empty Certificate message without terminating the connection. This document
-defines a TLS Flag {{!I-D.ietf-tls-tlsflags}} that enables clients to provide
-this hint.
+supports client authentication and will handle a CertificateRequest gracefully.
+This document defines a TLS Flag {{!I-D.ietf-tls-tlsflags}} that enables clients
+to provide this hint.
 
 
 --- middle
 
 # Introduction
 
-This document specifies a TLS Flag that indicates to the server that the client
-supports mutually authenticated TLS (in at least some cases). Sometimes a server
-does not want to authenticate every client, but might wish to authenticate a
-subset of them. In TLS 1.3 this may be done with post-handshake auth, however
-this adds an extra round-trip, and requires negotiation at the application
-layer.
+This document specifies a TLS Flag that allows a client to attempt to negotiate
+mutually authenticated TLS (in at least some cases). Sometimes a server does not
+want to authenticate every client, but might wish to authenticate a subset of
+them. In TLS 1.3 this may be done with post-handshake auth, however this adds an
+extra round-trip, and requires negotiation at the application layer.
 
 The behaviour specified in {{?RFC8446}} for a client that receives a
-CertificateRequest that it cannot satisfy is to send an empty Certificate
-message followed by a Finished message. However in practice many clients simply
+`CertificateRequest` that it cannot satisfy is to send an empty Certificate
+message followed by a `Finished` message. However in practice many clients simply
 terminate the connection in anticipation of a "certificate_required" alert.
 
-This behaviour makes it difficult for servers to send CertificateRequest
-messages in the wild. A client sending the request mTLS flag in the ClientHello
+This behaviour makes it difficult for servers to send `CertificateRequest`
+messages in the wild. A client sending the `request_mtls` flag in the `ClientHello`
 allows the server to request authentication during the initial handshake only
 when it receives a hint the client will handle the request without terminating
 the connection, and, if unable to authenticate, by sending an empty certificate
@@ -63,23 +61,44 @@ message, per {{?RFC8446, Section 4.4.2}}. This enables a number of use cases,
 for example allowing bots to authenticate themselves when mixed in with general
 traffic.
 
+This flag is intended to be used by clients sending automated traffic, not those
+that are directly operated by (human) users. Clients that set this flag SHOULD
+only do so when a client certificate is directly available to them, and MUST NOT
+prompt the user or take actions that would prompt the user for example trying to
+read certificates from off-board devices such as smart cards.
+
 # Conventions and Definitions
 
 {::boilerplate bcp14-tagged}
 
 # Flag specification
 
-A server receiving this flag MAY send a CertificateRequest message, and a client
-sending this flag MUST send a Certificate message if it receives a
-CertificateRequest, even if said Certificate message is empty, and SHOULD NOT
-preemptively terminate the connection anticipating a "certificate_required"
-alert.
+The `request_mtls` flag is sent by the client in the `ClientHello` message,
+and, if accepted by the server, acknowledged in the server's
+`CertificateRequest` message. A server that receives this flag and wishes to
+accept the extension MUST send a `CertificateRequest` message with the TLS
+Flags extension, and with the `request_mtls` flag set. The server MAY send a
+`CertificateRequest` message without the `request_mtls` flag set if it wishes
+to negotiate client authentication for another reason. The client sending this
+flag MUST send a `Certificate` message if it receives a `CertificateRequest`
+with the `request_mtls` flag set, even if said `Certificate` message is empty,
+and SHOULD NOT preemptively terminate the connection anticipating a
+"certificate_required" alert.
+
+A server receiving the `request_mtls` flag in a `ClientHello` message that
+wishes to accept the flag MUST echo the `request_mtls` flag in the
+`CertificateRequest` message. This informs the client that the reason for the
+`CertificateRequest` was because of the `request_mtls` flag and not due to some
+other policy. This allows clients to select certificates based on whether the
+server accepted the flag or not.
 
 # Security Considerations
 
 This flag should have no effect on the security of TLS, as the server may always
-send a CertificateRequest message during the handshake. This flag merely
-provides a hint that the client will handle the request gracefully.
+send a `CertificateRequest` message during the handshake. This flag merely
+provides a hint that the client will handle the request gracefully. Because the
+server acknowledges the flag in the `CertificateRequest` the client can always
+be sure whether a `CertificateRequest` was triggered by `request_mtls` or not.
 
 # IANA Considerations
 
@@ -88,7 +107,7 @@ namespace with the following values:
 
 * Value shall be TBD
 * Flag Name shall be request_mtls.
-* Message shall be CH
+* Message shall be CH, CR
 * Recommended shall be set to no (N)
 * The reference shall be this document {!draft-jhoyla-req-mtls}
 

--- a/draft-jhoyla-req-mtls-flag.md
+++ b/draft-jhoyla-req-mtls-flag.md
@@ -1,11 +1,11 @@
 ---
-title: "TLS Flag - Request mTLS"
+title: "TLS Flag - Request Client Auth"
 category: info
 
 docname: draft-jhoyla-req-mtls-flag-latest
 submissiontype: IETF  # also: "independent", "editorial", "IAB", or "IRTF"
 number: 0
-date: 25/05/27
+date: 25/05/29
 consensus: true
 v: 3
 # area: SEC
@@ -32,40 +32,42 @@ informative:
 --- abstract
 
 Normally in TLS there is no way for the client to signal to the server that it
-supports client authentication and will handle a CertificateRequest gracefully.
-This document defines a TLS Flag {{!I-D.ietf-tls-tlsflags}} that enables clients
-to provide this hint.
+supports client authentication and will handle a `CertificateRequest`
+gracefully. This document defines a TLS Flag that enables clients to provide
+this hint.
 
 
 --- middle
 
 # Introduction
 
-This document specifies a TLS Flag that allows a client to attempt to negotiate
-mutually authenticated TLS (in at least some cases). Sometimes a server does not
-want to authenticate every client, but might wish to authenticate a subset of
-them. In TLS 1.3 this may be done with post-handshake auth, however this adds an
-extra round trip, and requires negotiation at the application layer.
+This document specifies a TLS Flag {{!I-D.ietf-tls-tlsflags}} that allows a
+client to attempt to negotiate mutually authenticated TLS (in at least some
+cases). Sometimes a server does not want to authenticate every client, but
+might wish to authenticate a subset of them. In TLS 1.3 this may be done with
+post-handshake authentication, however this adds an extra round trip, and
+requires negotiation at the application layer.
 
 The behaviour specified in {{?RFC8446}} for a client that receives a
 `CertificateRequest` that it cannot satisfy is to send an empty Certificate
-message followed by a `Finished` message. However in practice many clients simply
-terminate the connection in anticipation of a "certificate_required" alert.
+message followed by a `Finished` message. However in practice many clients
+simply terminate the connection in anticipation of a "certificate_required"
+alert.
 
 This behaviour makes it difficult for servers to send `CertificateRequest`
-messages in the wild. A client sending the `request_mtls` flag in the `ClientHello`
-allows the server to request authentication during the initial handshake only
-when it receives a hint the client will handle the request without terminating
-the connection, and, if unable to authenticate, by sending an empty certificate
-message, per {{?RFC8446, Section 4.4.2}}. This enables a number of use cases,
-for example allowing bots to authenticate themselves when mixed in with general
-traffic.
+messages in the wild. A client sending the `request_client_auth` flag in the
+`ClientHello` allows the server to request authentication during the initial
+handshake only when it receives a hint the client will handle the request
+without terminating the connection, and, if unable to authenticate, by sending
+an empty certificate message, per {{?RFC8446, Section 4.4.2}}. This enables a
+number of use cases, for example allowing bots to authenticate themselves when
+mixed in with general traffic.
 
-This flag is intended to be used by clients sending automated traffic, not those
-that are directly operated by (human) users. Clients that set this flag SHOULD
-only do so when a client certificate is directly available to them, and MUST NOT
-prompt the user or take actions that would prompt the user for example trying to
-read certificates from off-board devices such as smart cards.
+This flag is intended to be used by clients sending automated traffic, not
+those that are directly operated by (human) users. Clients that set this flag
+SHOULD only do so when a client certificate is directly available to them, and
+MUST NOT prompt the user or take actions that would prompt the user for example
+trying to read certificates from off-board devices such as smart cards.
 
 # Conventions and Definitions
 
@@ -73,42 +75,52 @@ read certificates from off-board devices such as smart cards.
 
 # Flag specification
 
-The `request_mtls` flag is sent by the client in the `ClientHello` message,
-and, if accepted by the server, acknowledged in the server's
+The `request_client_auth` flag is sent by the client in the `ClientHello`
+message, and, if accepted by the server, acknowledged in the server's
 `CertificateRequest` message. A server that receives this flag and wishes to
 accept the extension MUST send a `CertificateRequest` message with the TLS
-Flags extension, and with the `request_mtls` flag set. The server MAY send a
-`CertificateRequest` message without the `request_mtls` flag set if it wishes
-to negotiate client authentication for another reason. The client sending this
-flag MUST send a `Certificate` message if it receives a `CertificateRequest`
-with the `request_mtls` flag set, even if said `Certificate` message is empty,
-and SHOULD NOT preemptively terminate the connection anticipating a
-"certificate_required" alert.
+Flags extension, and with the `request_client_auth` flag set. The server MAY
+send a `CertificateRequest` message without the `request_client_auth` flag set
+if it wishes to negotiate client authentication for another reason. This could
+occur if the server is configured to always request a client certificate. The
+client sending this flag MUST send a `Certificate` message if it receives a
+`CertificateRequest` with the `request_client_auth` flag set, even if said
+`Certificate` message is empty, and SHOULD NOT preemptively terminate the
+connection anticipating a "certificate_required" alert. Appropriate cases where
+a client would preemptively terminate the connection include where the
+`CertificateRequest` includes a `certificate_authorities` extension or
+`signature_algorithms` extension that the client cannot satisfy.
 
-A server receiving the `request_mtls` flag in a `ClientHello` message that
-wishes to accept the flag MUST echo the `request_mtls` flag in the
+A server receiving the `request_client_auth` flag in a `ClientHello` message
+that wishes to accept the flag MUST echo the `request_client_auth` flag in the
 `CertificateRequest` message. This informs the client that the reason for the
-`CertificateRequest` was because of the `request_mtls` flag and not due to some
-other policy. This allows clients to select certificates based on whether the
-server accepted the flag or not.
+`CertificateRequest` was because of the `request_client_auth` flag and not due
+to some other policy. This allows clients to select certificates based on
+whether the server accepted the flag or not.
 
-A server MUST NOT set the `request_mtls` flag in the `CertificateRequest` unless
-it received the flag in the `ClientHello`. A client receiving the `request_mtls`
-flag that did not set it in the `ClientHello` MUST generate a fatal
-`illegal_parameter` alert.
+A server MUST NOT set the `request_client_auth` flag in the
+`CertificateRequest` unless it received the flag in the `ClientHello`. A client
+receiving the `request_client_auth` flag that did not set it in the
+`ClientHello` MUST generate a fatal `illegal_parameter` alert.
+
+A client that receives this flag in any message other than `CertificateRequest`
+MUST terminate the connection with a fatal `illegal_parameter` alert. Similarly
+a server that receives this flag in any message other than `ClientHello` MUST
+terminate the connection with a fatal `illegal_parameter` alert.
 
 # Security Considerations
 
-This flag should have no effect on the security of TLS, as the server may always
-send a `CertificateRequest` message during the handshake. This flag merely
-provides a hint that the client will handle the request gracefully. Because the
-server acknowledges the flag in the `CertificateRequest` the client can always
-be sure whether a `CertificateRequest` was triggered by `request_mtls` or not.
+This flag should have no effect on the security of TLS, as the server may
+always send a `CertificateRequest` message during the handshake. This flag
+merely provides a hint that the client will handle the request gracefully.
+Because the server acknowledges the flag in the `CertificateRequest` the client
+can always be sure whether a `CertificateRequest` was triggered by
+`request_client_auth` or not.
 
 # IANA Considerations
 
-This document requests IANA to add an entry to the TLS Flags registry in the TLS
-namespace with the following values:
+This document requests IANA to add an entry to the TLS Flags registry in the
+TLS namespace with the following values:
 
 * Value shall be TBD
 * Flag Name shall be request_mtls.

--- a/draft-jhoyla-req-mtls-flag.md
+++ b/draft-jhoyla-req-mtls-flag.md
@@ -45,7 +45,7 @@ This document specifies a TLS Flag that allows a client to attempt to negotiate
 mutually authenticated TLS (in at least some cases). Sometimes a server does not
 want to authenticate every client, but might wish to authenticate a subset of
 them. In TLS 1.3 this may be done with post-handshake auth, however this adds an
-extra round-trip, and requires negotiation at the application layer.
+extra round trip, and requires negotiation at the application layer.
 
 The behaviour specified in {{?RFC8446}} for a client that receives a
 `CertificateRequest` that it cannot satisfy is to send an empty Certificate
@@ -91,6 +91,11 @@ wishes to accept the flag MUST echo the `request_mtls` flag in the
 `CertificateRequest` was because of the `request_mtls` flag and not due to some
 other policy. This allows clients to select certificates based on whether the
 server accepted the flag or not.
+
+A server MUST NOT set the `request_mtls` flag in the `CertificateRequest` unless
+it received the flag in the `ClientHello`. A client receiving the `request_mtls`
+flag that did not set it in the `ClientHello` MUST generate a fatal
+`illegal_parameter` alert.
 
 # Security Considerations
 


### PR DESCRIPTION
Clients that receive `CertificateRequest`s in practice will terminate the connection in anticipation of a "certificate_required" alert, rather than sending an empty `Certificate` message, as specified in [RFC-8446, Section 4.4.2](https://www.rfc-editor.org/rfc/rfc8446#section-4.4.2).
This PR updates the draft to specify that the client MUST send an empty `Certificate` message, and SHOULD NOT terminate the connection in anticipation of a "certificate_required" alert.
We can't require a MUST NOT terminate the connection, as the client might want to terminate the connection for other, unrelated reasons.